### PR TITLE
Bug fixing

### DIFF
--- a/src/matching/Injection.cpp
+++ b/src/matching/Injection.cpp
@@ -33,6 +33,7 @@ bool CcInjection::reuse(const pattern::Pattern::Component& _cc,Node& node,
 		n = nullptr;
 	//if(_cc.getAgent(root).getId() == node.getId()){
 	ccAgToNode.resize(_cc.size(),nullptr);
+	map<Node*,small_id> nodeToCcAg;
 	std::list<pair<small_id,Node*> > q;
 	q.emplace_back(root,&node);
 	const pattern::Mixture::Agent* ag;
@@ -51,18 +52,22 @@ bool CcInjection::reuse(const pattern::Pattern::Component& _cc,Node& node,
 			if(next_node.second->getId() != short_id(-1)){//compare different pointers
 				next_node.first = _cc.follow(q.front().first,site.getId()).first;
 				//need to check site of links?? TODO No
-				if(ccAgToNode[next_node.first]){
-					if(ccAgToNode[next_node.first] != next_node.second)
-						return false;
-				}
+				//if(next_node.first >= _cc.size())
+				//	return false;
+				if(nodeToCcAg.count(next_node.second) && nodeToCcAg[next_node.second] != next_node.first)
+					return false;
+				if(ccAgToNode[next_node.first] && ccAgToNode[next_node.first] != next_node.second)
+					return false;
 				else {
 					q.emplace_back(next_node);
 					ccAgToNode[next_node.first] = next_node.second;//todo review
+					nodeToCcAg[next_node.second] = next_node.first;//todo review
 				}
 				//next_node.second = nullptr;
 			}
 		}
 		ccAgToNode[q.front().first] = q.front().second;//case when agent mixture with no sites
+		nodeToCcAg[next_node.second] = next_node.first;//todo review
 		q.pop_front();
 	}
 	return true;

--- a/src/pattern/mixture/Agent.cpp
+++ b/src/pattern/mixture/Agent.cpp
@@ -88,8 +88,7 @@ bool Pattern::Agent::testEmbed(const Agent &rhs_ag,
 	if(signId != rhs_ag.signId)
 		return false;
 
-	set<small_id> already_done;
-	for(auto &site : rhs_ag.interface){
+	for(auto &site : rhs_ag.interface){//every site in RHS-ag must be tested
 		auto& lhs_site = getSiteSafe(site.getId());
 		if(lhs_site.testEmbed(site,context)){
 			if(site.getLinkType() == BND &&
@@ -634,7 +633,7 @@ void Pattern::Site::setMatchFunction(){
 
 
 string Pattern::Site::toString(small_id sign_id, small_id ag_pos,
-		map<ag_st_id,short> bindLabels, const Environment &env) const {
+		const map<ag_st_id,short>& bindLabels, const Environment &env) const {
 	string out;
 	auto& sign = env.getSignature(sign_id).getSite(id);
 	out += sign.getName(); //site name
@@ -671,8 +670,8 @@ string Pattern::Site::toString(small_id sign_id, small_id ag_pos,
 	case LinkType::FREE :
 		break;
 	case LinkType::BND :
-		if ( bindLabels.size() > 0 && bindLabels[ag_st_id(ag_pos,id)] )
-			out += "!" + to_string( bindLabels[ag_st_id(ag_pos,id)] );
+		if ( bindLabels.size() > 0 && bindLabels.count(ag_st_id(ag_pos,id) ) )
+			out += "!" + to_string( bindLabels.at(ag_st_id(ag_pos,id)) );
 		else{
 			auto& signature2bind = env.getSignature( lnk_ptrn.first );
 			auto& site2bind = signature2bind.getSite( lnk_ptrn.second );

--- a/src/pattern/mixture/Agent.h
+++ b/src/pattern/mixture/Agent.h
@@ -144,7 +144,7 @@ public:
 		return id < site.id;
 	}
 
-	string toString(small_id,small_id ag_pos,map<ag_st_id,short> bindLabels,
+	string toString(small_id,small_id ag_pos,const map<ag_st_id,short>& bindLabels,
 			const Environment& env) const;
 };
 

--- a/src/pattern/mixture/Component.cpp
+++ b/src/pattern/mixture/Component.cpp
@@ -57,13 +57,16 @@ void Pattern::Component::addBind(ag_st_id p1,ag_st_id p2){
 }
 
 map<small_id,small_id> Pattern::Component::declareAgents(Environment &env){
-	map<Agent*,small_id> old_order;
+	vector<pair<Agent*,small_id>> old_order;
 	map<small_id,small_id> order_mask;//old-pos -> new-pos
 	for(unsigned i = 0; i < agents.size(); i++){
 		env.declareAgentPattern(agents[i]);//this can change agent pointer
-		old_order.emplace(agents[i],i);
+		old_order.emplace_back(agents[i],small_id(i));
 	}
-	sort(agents.begin(),agents.end());//sorts in pointer order
+	stable_sort(agents.begin(),agents.end());//sorts in pointer order
+	stable_sort(old_order.begin(),old_order.end(),[](const pair<Agent*,small_id>& a,const pair<Agent*,small_id>& b) -> bool {
+		return a.first < b.first;
+	});
 	//if(agents.size() == 1)
 	//	return order_mask;//debugging purposes
 	small_id i = 0;
@@ -181,10 +184,9 @@ string Pattern::Component::toString(const Environment& env) const {
 		 * the graph is bidirectional because the links are symmetrical, that means exist [ag_id,site_id],[ag_id',site_id'0]
 		 * and [ag_id',site_id'],[ag_id,site_id]
 		 */
-		if( ! bindLabels[ag_st_id(lnk->first.first, lnk->first.second)] &&
-				! bindLabels[ag_st_id(lnk->second.first, lnk->second.second)] ) {
-			bindLabels[ag_st_id(lnk->first.first, lnk->first.second)] = bindLabel;
-			bindLabels[ag_st_id(lnk->second.first, lnk->second.second)] = bindLabel;
+		if( !bindLabels.count(lnk->first) && !bindLabels.count(lnk->second) ) {
+			bindLabels[lnk->first] = bindLabel;
+			bindLabels[lnk->second] = bindLabel;
 			bindLabel++;
 
 		}

--- a/src/pattern/mixture/Mixture.cpp
+++ b/src/pattern/mixture/Mixture.cpp
@@ -73,10 +73,6 @@ void Mixture::addBindLabel(int lbl, small_id ag_pos,small_id site_id){
 			binds.emplace(p1,p2);
 		else
 			binds.emplace(p2,p1);
-		agents[p1.first]->getSite(p1.second).lnk_ptrn =
-				ag_st_id(agents[p2.first]->getId(),p2.second);
-		agents[p2.first]->getSite(p2.second).lnk_ptrn =
-				ag_st_id(agents[p1.first]->getId(),p1.second);
 	}
 	else if(sites.size() > 2)
 		throw SemanticError("Edge identifier "+to_string(lbl)+
@@ -85,6 +81,7 @@ void Mixture::addBindLabel(int lbl, small_id ag_pos,small_id site_id){
 
 void Mixture::declareComponents(Environment &env){
 	int cc_pos = 0;
+	//cout << "before reorder: " << toString(env) << endl;
 	for(auto& comp : comps){
 		auto order_mask = env.declareComponent(comp);
 		for(auto swap : order_mask){//updating possible agent pointer change and positions
@@ -105,6 +102,7 @@ void Mixture::declareComponents(Environment &env){
 	}
 	for(auto aux : auxRefs)
 		aux->coords = auxCoords.at(aux->toString());
+	//cout << "after reorder: " << toString(env) << endl;
 }
 
 void Mixture::setComponents(){
@@ -119,6 +117,11 @@ void Mixture::setComponents(){
 	for(auto l_it = binds.cbegin();l_it != binds.cend(); l_it++){
 		auto p1 = l_it->first,p2 = l_it->second;
 		auto c_it = comps.begin();
+
+		agents[p1.first]->getSite(p1.second).lnk_ptrn =
+				ag_st_id(agents[p2.first]->getId(),p2.second);
+		agents[p2.first]->getSite(p2.second).lnk_ptrn =
+				ag_st_id(agents[p1.first]->getId(),p1.second);
 		//iterate on local components, test if ag(p1) or ag(p2) \in comp
 		unsigned cc_pos = 0;
 		for(;c_it != comps.end(); c_it++,cc_pos++){

--- a/src/pattern/mixture/Pattern.h
+++ b/src/pattern/mixture/Pattern.h
@@ -21,7 +21,7 @@ namespace simulation {
 
 namespace pattern {
 //Forward declaration needed for setComponents() and toString()
-//class Environment;
+class Environment;
 using namespace std;
 
 /* Abstract class Pattern *
@@ -65,6 +65,7 @@ public:
 	virtual void addInclude(small_id id){
 		includes.emplace(id);
 	}
+	virtual string toString(const Environment& env) const = 0;
 };
 
 class Mixture;

--- a/src/simulation/Parameters.cpp
+++ b/src/simulation/Parameters.cpp
@@ -138,7 +138,7 @@ void Parameters::evalOptions(int argc, char* argv[]){
 	}
 	if(vm.count("verbose")){
 		verbose = vm["verbose"].as<int>();
-		if(verbose < 0 || verbose > 3){
+		if(verbose < 0 || verbose > 10){
 			cout << "Not a valid value for --verbose parameter." << endl;
 			exit(1);
 		}

--- a/src/simulation/Rule.cpp
+++ b/src/simulation/Rule.cpp
@@ -332,20 +332,21 @@ void Rule::checkInfluence(const Environment &env,const SimContext &context) {
 	}
 	//Checking candidates
 	map<int,set<ag_st_id>> already_done;//cc-id -> every match (cc-ag -> rhs-ag)
-	//cout << "testing if rule " << this->getName() << " have influence on candidates CC:" << endl;
+	cout << "testing if rule " << this->getName() << " have influence on candidates CC:" << endl;
 	for(auto& key_info : candidates){
 		auto& key = key_info.first;
 		auto rhs_coords = rhs->getAgentCoords(key_info.first.match_root.second);
 		ag_st_id root(key.match_root.first,rhs_coords.second);//agent-pos in ptrn -> agent-pos in rhc-cc
 		if(already_done[key.cc->getId()].count(root))
 			continue;//this match for this cc is already done TODO print this
-		//cout << "\t" << cc_info.first->toString(env);
+		//cout << "\t" << key.cc->toString(env);
 		map<small_id,small_id> emb;
 		if(key.cc->testEmbed(rhs->getComponent(rhs_coords.first),root,context,emb)){
 			already_done[key.cc->getId()].insert(emb.begin(),emb.end());
 			influence.emplace(key_info);
-		//else cout << " | NO!";
+			//cout << " | YES!";
 		}
+		//else cout << " | NO!";
 		//cout << endl;
 	}
 

--- a/src/state/State.cpp
+++ b/src/state/State.cpp
@@ -174,6 +174,7 @@ void State::apply(const simulation::Rule& r){
 void State::positiveUpdate(const simulation::Rule::CandidateMap& wake_up){
 	//TODO vars_to_wake_up
 	//auto& wake_up = r.getInfluences();
+	int new_injs = 0;
 	for(auto& key_info : wake_up){
 		auto key = key_info.first;
 		auto info = key_info.second;
@@ -182,9 +183,21 @@ void State::positiveUpdate(const simulation::Rule::CandidateMap& wake_up){
 		//if(info.infl_by.size() && distance(nulls.first,nulls.second) == info.infl_by.size())
 		//	continue;	//every action applied to node is null
 		map<int,matching::InjSet*> port_list;
-		auto inj_p = injections[key.cc->getId()]->emplace(*node,port_list,*this,key.match_root.first);
+		auto inj_p = injections[key.cc->getId()]->
+				emplace(*node,port_list,*this,key.match_root.first);
 
 		if(inj_p){
+#ifdef DEBUG
+			if(simulation::Parameters::get().verbose > 3){
+				if(new_injs == 0)
+					cout << "New injections found:\n";
+				cout << "\tPattern " << inj_p->pattern().toString(env) << " matches with agents IDs ";
+				for(auto& node : inj_p->getEmbedding())
+					cout << node->getAddress() << ",";
+				cout << endl;
+				new_injs++;
+			}
+#endif
 			for(;nulls.first != nulls.second;++nulls.first)
 				port_list.erase(nulls.first->second);
 			if(port_list.empty())//TODO check cc.size()
@@ -241,7 +254,7 @@ void State::advanceUntil(FL_TYPE sync_t,UINT_TYPE max_e) {
 			if(ex.error){
 				counter.incNullEvents(ex.error);
 				#ifdef DEBUG
-					cout << "\tnull-event (" << ex.what() << ")" << endl;
+					cout << "  | Null-Event (" << ex.what() << ")" << endl;
 				#endif
 			}
 			else
@@ -249,7 +262,7 @@ void State::advanceUntil(FL_TYPE sync_t,UINT_TYPE max_e) {
 		}
 		catch(const NullEvent &ex){
 			#ifdef DEBUG
-				cout << "\tnull-event (" << ex.what() << ")" << endl;
+				cout << "  | Null-Event (" << ex.what() << ")" << endl;
 			#endif
 			counter.incNullEvents(ex.error);
 		}


### PR DESCRIPTION
- Using stable_sort to keep agent order of CC.
- CcInjection::reuse(): check if the node is already used as an agent
match of the CC.