### PR TITLE
Non-local instances

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="1239984265630252411" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="-1152447639830141210" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="1239984265630252411" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="-1152447639830141210" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Debug/src/data_structs/subdir.mk
+++ b/Debug/src/data_structs/subdir.mk
@@ -8,21 +8,24 @@ CPP_SRCS += \
 ../src/data_structs/MaskedBinaryRandomTree.cpp \
 ../src/data_structs/MyMaskedBinaryRandomTree.cpp \
 ../src/data_structs/RandomTree.cpp \
-../src/data_structs/SimpleSet.cpp 
+../src/data_structs/SimpleSet.cpp \
+../src/data_structs/SimpleTree.cpp 
 
 OBJS += \
 ./src/data_structs/DistributionTree.o \
 ./src/data_structs/MaskedBinaryRandomTree.o \
 ./src/data_structs/MyMaskedBinaryRandomTree.o \
 ./src/data_structs/RandomTree.o \
-./src/data_structs/SimpleSet.o 
+./src/data_structs/SimpleSet.o \
+./src/data_structs/SimpleTree.o 
 
 CPP_DEPS += \
 ./src/data_structs/DistributionTree.d \
 ./src/data_structs/MaskedBinaryRandomTree.d \
 ./src/data_structs/MyMaskedBinaryRandomTree.d \
 ./src/data_structs/RandomTree.d \
-./src/data_structs/SimpleSet.d 
+./src/data_structs/SimpleSet.d \
+./src/data_structs/SimpleTree.d 
 
 
 # Each subdirectory must supply rules for building sources it contributes

--- a/Debug/src/matching/subdir.mk
+++ b/Debug/src/matching/subdir.mk
@@ -4,14 +4,17 @@
 
 # Add inputs and outputs from these tool invocations to the build variables 
 CPP_SRCS += \
+../src/matching/CcInjection.cpp \
 ../src/matching/InjRandSet.cpp \
 ../src/matching/Injection.cpp 
 
 OBJS += \
+./src/matching/CcInjection.o \
 ./src/matching/InjRandSet.o \
 ./src/matching/Injection.o 
 
 CPP_DEPS += \
+./src/matching/CcInjection.d \
 ./src/matching/InjRandSet.d \
 ./src/matching/Injection.d 
 

--- a/Release/src/data_structs/subdir.mk
+++ b/Release/src/data_structs/subdir.mk
@@ -8,21 +8,24 @@ CPP_SRCS += \
 ../src/data_structs/MaskedBinaryRandomTree.cpp \
 ../src/data_structs/MyMaskedBinaryRandomTree.cpp \
 ../src/data_structs/RandomTree.cpp \
-../src/data_structs/SimpleSet.cpp 
+../src/data_structs/SimpleSet.cpp \
+../src/data_structs/SimpleTree.cpp 
 
 OBJS += \
 ./src/data_structs/DistributionTree.o \
 ./src/data_structs/MaskedBinaryRandomTree.o \
 ./src/data_structs/MyMaskedBinaryRandomTree.o \
 ./src/data_structs/RandomTree.o \
-./src/data_structs/SimpleSet.o 
+./src/data_structs/SimpleSet.o \
+./src/data_structs/SimpleTree.o 
 
 CPP_DEPS += \
 ./src/data_structs/DistributionTree.d \
 ./src/data_structs/MaskedBinaryRandomTree.d \
 ./src/data_structs/MyMaskedBinaryRandomTree.d \
 ./src/data_structs/RandomTree.d \
-./src/data_structs/SimpleSet.d 
+./src/data_structs/SimpleSet.d \
+./src/data_structs/SimpleTree.d 
 
 
 # Each subdirectory must supply rules for building sources it contributes

--- a/Release/src/matching/subdir.mk
+++ b/Release/src/matching/subdir.mk
@@ -4,14 +4,17 @@
 
 # Add inputs and outputs from these tool invocations to the build variables 
 CPP_SRCS += \
+../src/matching/CcInjection.cpp \
 ../src/matching/InjRandSet.cpp \
 ../src/matching/Injection.cpp 
 
 OBJS += \
+./src/matching/CcInjection.o \
 ./src/matching/InjRandSet.o \
 ./src/matching/Injection.o 
 
 CPP_DEPS += \
+./src/matching/CcInjection.d \
 ./src/matching/InjRandSet.d \
 ./src/matching/Injection.d 
 

--- a/src/data_structs/DebugPtrSet.h
+++ b/src/data_structs/DebugPtrSet.h
@@ -1,0 +1,34 @@
+/*
+ * SafePtrSet.h
+ *
+ *  Created on: Jul 7, 2021
+ *      Author: naxo
+ */
+
+#ifndef SRC_DATA_STRUCTS_DEBUGPTRSET_H_
+#define SRC_DATA_STRUCTS_DEBUGPTRSET_H_
+
+#include <set>
+
+#ifdef DEBUG
+template <typename T>
+class DebugPtrSet : public std::set<T*> {
+public:
+	inline auto emplace(T* elem) {
+		for(auto elem_it : *this)
+			if(*elem == *elem_it)
+				throw std::invalid_argument("DebugPtrSet::emplace(): same element twice.");
+		return std::set<T*>::emplace(elem);
+	}
+	using std::set<T*>::erase;
+};
+
+#else
+template <typename T>
+class DebugPtrSet : public std::set<T*>{};
+#endif
+
+
+
+
+#endif /* SRC_DATA_STRUCTS_DEBUGPTRSET_H_ */

--- a/src/data_structs/DistributionTree.cpp
+++ b/src/data_structs/DistributionTree.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "DistributionTree.h"
-#include "../matching/Injection.h"
+#include "../matching/CcInjection.h"
 #include <iostream>
 #include <string>
 #include <algorithm>
@@ -177,7 +177,7 @@ void Node<T>::decrease(FL_TYPE val,unsigned n){
 }
 
 template <typename T>
-const T& Node<T>::choose(FL_TYPE sel) const {
+T& Node<T>::choose(FL_TYPE sel) const {
 	if(smaller){
 		if(sel < smaller->total())
 			return smaller->choose(sel);
@@ -201,8 +201,28 @@ const T& Node<T>::choose(FL_TYPE sel) const {
 }
 
 template <typename T>
-const pair<T*,FL_TYPE>& Node<T>::choose(unsigned sel) const {
-	throw std::invalid_argument("Node<T>::choose() not available");
+pair<T*,FL_TYPE> Node<T>::choose(unsigned sel) const {
+	//throw std::invalid_argument("Node<T>::choose() not available");
+	if(smaller){
+		if(sel < smaller->count())
+			return smaller->choose(sel);
+		else
+			sel -= smaller->count();
+	}
+	if(greater){
+		if(sel < greater->count())
+			return greater->choose(sel);
+		else
+			sel -= greater->count();
+	}
+	for(auto inj : multi_injs){
+		auto r_multi = inj->count();
+		if(sel < r_multi)
+			return make_pair(inj,this->value);
+		else
+			sel -= r_multi;
+	}
+	return make_pair(this->injs[sel],this->value);
 }
 
 template <typename T>
@@ -456,7 +476,7 @@ void Leaf<T>::clear(list<T*>* free){
 }
 
 template <typename T>
-const T& Leaf<T>::choose(FL_TYPE sel) const {
+T& Leaf<T>::choose(FL_TYPE sel) const {
 	/*auto p = injs[int(count() * sel / this->sum)].first;
 	if(p == nullptr){
 		std::cout << "BAD!!!" << std::endl;
@@ -467,7 +487,7 @@ const T& Leaf<T>::choose(FL_TYPE sel) const {
 
 
 template <typename T>
-const pair<T*,FL_TYPE>& Leaf<T>::choose(unsigned i) const {
+pair<T*,FL_TYPE> Leaf<T>::choose(unsigned i) const {
 	return injs[i];
 }
 
@@ -518,6 +538,14 @@ bool Leaf<T>::testBalance() const {
 template class DistributionTree<matching::CcValueInj>;
 template class Node<matching::CcValueInj>;
 template class Leaf<matching::CcValueInj>;
+/*
+template class DistributionTree<matching::CcInjection>;
+template class Node<matching::CcInjection>;
+template class Leaf<matching::CcInjection>;
 
+template class DistributionTree<matching::MixInjection>;
+template class Node<matching::MixInjection>;
+template class Leaf<matching::MixInjection>;
+*/
 }
 

--- a/src/data_structs/DistributionTree.h
+++ b/src/data_structs/DistributionTree.h
@@ -54,9 +54,9 @@ public:
 	virtual void decrease(FL_TYPE val,unsigned n = 1) = 0;
 
 	/** \brief Returns an element of the tree corresponding with the value of r. */
-	virtual const T& choose(FL_TYPE r) const = 0;
+	virtual T& choose(FL_TYPE r) const = 0;
 	/** \brief Returns the i-th element in the tree. */
-	virtual const pair<T*,FL_TYPE>& choose(unsigned i) const = 0;
+	virtual pair<T*,FL_TYPE> choose(unsigned i) const = 0;
 	/** \brief Returns the number of elements in this subtree. */
 	virtual unsigned count() const = 0;
 	/** \brief Adds the element inj to the subtree based on val. */
@@ -111,8 +111,8 @@ public:
 	Node(Leaf<T>* leaf,FL_TYPE val = 0.0);
 	virtual ~Node();
 	virtual void deleteContent() override;
-	virtual const T& choose(FL_TYPE r) const override;
-	virtual const pair<T*,FL_TYPE>& choose(unsigned i) const override;
+	virtual T& choose(FL_TYPE r) const override;
+	virtual pair<T*,FL_TYPE> choose(unsigned i) const override;
 	virtual unsigned count() const override;
 
 	virtual void push(T* inj,FL_TYPE val) override;
@@ -163,8 +163,8 @@ public:
 	Leaf(Node<T>* _parent);
 	virtual ~Leaf();
 	virtual void deleteContent();
-	const T& choose(FL_TYPE r) const override;
-	virtual const pair<T*,FL_TYPE>& choose(unsigned r) const override;
+	T& choose(FL_TYPE r) const override;
+	virtual pair<T*,FL_TYPE> choose(unsigned r) const override;
 	virtual unsigned count() const override;
 
 	virtual void push(T* elem,FL_TYPE val) override;

--- a/src/data_structs/SimpleTree.cpp
+++ b/src/data_structs/SimpleTree.cpp
@@ -1,0 +1,39 @@
+/*
+ * SimpleTree.cpp
+ *
+ *  Created on: Sep 21, 2021
+ *      Author: naxo
+ */
+
+#include "SimpleTree.h"
+
+
+namespace data_structs {
+
+SimpleTree::SimpleTree(int n) : size(n) {
+	acts = new FL_TYPE[n];
+	sum = 0;
+}
+
+SimpleTree::~SimpleTree() {
+	delete[] acts;
+}
+
+/** \brief Choose random node from tree with probability = weight/total().
+ */
+std::pair<int,FL_TYPE> SimpleTree::chooseRandom() {
+	FL_TYPE select = rand() * sum / RAND_MAX;
+	//static int rnd(0);
+	//FL_TYPE select = (rnd++)%100 * sum / 100.0;
+	int i = 0;
+	do {
+		if(select < acts[i])
+			return std::make_pair(i,acts[i]);
+		select -= acts[i];
+		i++;
+	} while(i < size);
+	throw std::invalid_argument("at SimpleTree::chooseRandom()");
+}
+
+}
+

--- a/src/data_structs/SimpleTree.h
+++ b/src/data_structs/SimpleTree.h
@@ -1,0 +1,64 @@
+/*
+ * SimpleTree.h
+ *
+ *  Created on: Sep 21, 2021
+ *      Author: naxo
+ */
+
+#ifndef SRC_DATA_STRUCTS_SIMPLETREE_H_
+#define SRC_DATA_STRUCTS_SIMPLETREE_H_
+
+#include "RandomTree.h"
+
+namespace data_structs {
+
+class SimpleTree: public RandomTree {
+	int size;
+	FL_TYPE* acts;
+	FL_TYPE sum;
+public:
+	SimpleTree(int n);
+	virtual ~SimpleTree();
+
+	/** Update all the nodes.
+	*/
+	virtual void update() {};
+
+	/** \brief Number of nodes of the Chain.
+	 */
+	virtual int getSize() const {
+		return size;
+	}
+
+	/** \brief Calculate total sum of nodes.
+	 */
+	virtual FL_TYPE total() {
+		return sum;
+	}
+
+	/** \brief Add or change a value of a node in the chain.
+	 */
+	virtual void add(int id, FL_TYPE val){
+		sum += val-acts[id];
+		acts[id] = val;
+	}
+
+	/** \brief Choose random node from tree with probability = weight/total().
+	 */
+	virtual std::pair<int,FL_TYPE> chooseRandom();
+
+	/** \brief Check if the rule "i" has an infinity probability.
+	*/
+	virtual bool isInfinite(int i) {return false;};
+
+	/** \brief Return the probability of the rule "i"
+	*/
+	virtual FL_TYPE find(int i) {
+		return acts[i];
+	}
+};
+
+
+}
+
+#endif /* SRC_DATA_STRUCTS_SIMPLETREE_H_ */

--- a/src/expressions/BaseExpression.h
+++ b/src/expressions/BaseExpression.h
@@ -77,7 +77,7 @@ public:
 		RAND_1,SIM_TIME,CPUTIME,ACTIVITY,		///< FLOAT
 		RUN_ID,SIM_EVENT,NULL_EVENT,PROD_EVENT,	///< INT
 		END_SIM									///< BOOL
-	};
+	};//check histogram if new bool nullary
 	/** \brief Dependencies that an expression can have. */
 	enum VarDep {
 		CONSTS = 1,RUN = 2,AUX = 4,SPATIAL = 8,TIME = 16,EVENT = 32,RAND = 64,VARDEP = 128

--- a/src/grammar/ast/Dynamics.h
+++ b/src/grammar/ast/Dynamics.h
@@ -210,6 +210,7 @@ public:
 		UPDATE_TOK,	///< Sets a new value to a token variable (\<-).
 		STOP,		///< Stop the simulation.
 		SNAPSHOT,	///< Save the current state of the simulation to a file.
+		HISTOGRAM,	///< Print histogram-like data to file.
 		PRINT,		///< Write text to the standard output.
 		PRINTF,		///< Write text to a file.
 		CFLOW,
@@ -238,7 +239,7 @@ public:
 	//Effect& operator=(const Effect& eff);
 
 	simulation::Perturbation::Effect* eval(pattern::Environment& env,
-			const SimContext &context) const;
+			const SimContext &context,const BaseExpression* trigger = nullptr) const;
 
 	void show(string tabs = "") const;
 
@@ -277,32 +278,21 @@ protected:
 	list<Effect> effects;
 };
 
-/** \brief The rate and radius for the unary instance of a rule. */
-struct Radius : Node {
-	const Expression *k1;
-	const Expression *opt;
-public:
-	Radius();
-	Radius(const location &l,const Expression *k1);
-	Radius(const location &l,const Expression *k1,const Expression *opt);
-	~Radius();
-};
-
 /** \brief The AST of the rate(s) of a rule. */
 class Rate : Node {
 	const Expression *base;		///< The base rate of the rule.
 	const Expression *reverse;	///< The rate for the backward rule.
-	Radius *unary;				///< The rate for unary instances of the rule.
 	bool volFixed;				///< do not depend on volume
 	bool fixed;					///< do not depend on concentrations
+	two<const Expression*> unary;///< The (rate,radius) for unary instances of the rule.
 public:
 	Rate();
 	Rate(const Rate& rate);
 	Rate& operator=(const Rate& rate);
 	Rate(const location &l,const Expression *def,const bool fix);
-	Rate(const location &l,const Expression *def,const bool fix,const Radius *un);
+	Rate(const location &l,const Expression *def,const bool fix,two<const Expression*> un);
 	Rate(const location &l,const Expression *def,const bool fix,const Expression *op);
-	const state::BaseExpression* eval(const pattern::Environment& env,simulation::Rule& r,
+	const state::BaseExpression* eval(pattern::Environment& env,simulation::Rule& r,
 			const SimContext &context,two<pattern::DepSet>& deps,
 			bool is_bi = false) const;
 	~Rate();

--- a/src/grammar/ast/KappaAst.cpp
+++ b/src/grammar/ast/KappaAst.cpp
@@ -87,7 +87,7 @@ vector<Variable*> KappaAst::evaluateDeclarations(pattern::Environment &env,SimCo
  *     Each float value will be associated to a parameter in the same order that
  *     they were declared in the model. This overwrite every previous value. */
 void KappaAst::evaluateParams(pattern::Environment &env,SimContext &context,const vector<float>& po_params){
-	if(params.size() > po_params.size())
+	if(params.size() < po_params.size())
 		throw invalid_argument("Too many parameters given as command line argument.");
 	unsigned i = 0;
 	auto& vars = context.getVars();

--- a/src/grammar/kappa3/Lexer.l
+++ b/src/grammar/kappa3/Lexer.l
@@ -117,7 +117,7 @@ real		([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)(([eE][+-][0-9]+)|([eE][0-9]+))?
 	else if(!strcmp(yytext,"$SNAPSHOT"))
 		return Parser::make_SNAPSHOT(loc);
 	else if(!strcmp(yytext,"$HISTOGRAM"))
-		return Parser::make_SNAPSHOT(loc);
+		return Parser::make_HIST(loc);
 	else if(!strcmp(yytext,"$STOP"))
 		return Parser::make_STOP(loc);
 	else if(!strcmp(yytext,"$FLUX"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ using namespace simulation;
 using namespace std;
 
 int main(int argc, char* argv[]){
-	const string version("2.1.04");
+	const string version("2.2.09");
 	const string v_msg("KaXim "+version);
 	const string usage_msg("Simple usage is \n$ "
 			"KaXim ([-i] kappa_file)+ -t time [-p points] [-r runs]");
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]){
 
 	//eval given arguments to the program
 	auto& params = simulation::Parameters::singleton;
-	params.makeOptions(v_msg + "\n" + usage_msg + "\n\nAllowed options");
+	params.makeOptions(v_msg,usage_msg,"Allowed options");
 	params.evalOptions(argc, argv);
 
 	//Reading kappa-model files (if any)
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]){
 		ast.evaluateInits(env,base_context);
 	}
 	catch(const exception &e){
-		cerr << "An exception found while building the environment:\n" << e.what() << endl;
+		cerr << "An exception found while building the environment.\n" << e.what() << endl;
 		exit(1);
 	}
 	env.buildFreeSiteCC();
@@ -134,14 +134,14 @@ int main(int argc, char* argv[]){
 #	pragma omp parallel for
 	for(int i = 0; i < params.runs; i++){
 		Simulation sim(base_context,i);
-		try{
+		//try{
 			sim.initialize(cells,ast);
-		}
+		/*}
 		catch(const exception &e){
 			cerr << "An exception found on initialization of simulation["
 					<< i << "]: " << e.what() << endl;
 			exit(1);
-		}
+		}*/
 
 		if(i == 0)
 			WarningStack::getStack().show();

--- a/src/matching/CcInjection.cpp
+++ b/src/matching/CcInjection.cpp
@@ -1,0 +1,130 @@
+/*
+ * CcInjection.cpp
+ *
+ *  Created on: Oct 7, 2021
+ *      Author: naxo
+ */
+
+#include "CcInjection.h"
+/*
+#include "../state/State.h"
+#include "../expressions/Vars.h"
+#include "../pattern/mixture/Component.h"
+#include "../pattern/mixture/Agent.h"
+*/
+namespace matching {
+
+
+
+/********** CcInjection **********/
+CcInjection::CcInjection(const pattern::Pattern& _cc) :
+		Injection(_cc),ccAgToNode(_cc.size(),nullptr) {}
+
+/*CcInjection::CcInjection(const pattern::Pattern& _cc) : Injection(_cc) {};
+
+CcInjection::CcInjection(const pattern::Pattern::Component& _cc)
+		: Injection(_cc),ccAgToNode(_cc.size(),nullptr) {
+	//reuse(_cc,node,port_list,root);
+}*/
+
+bool CcInjection::reuse(const simulation::SimContext& context,
+		Node* node,map<int,InjSet*>& port_list, small_id root) {
+	//ccAgToNode.clear();
+	for(auto& n : ccAgToNode)
+		n = nullptr;
+	//if(_cc.getAgent(root).getId() == node.getId()){
+	ccAgToNode.resize(ptrn.size(),nullptr);
+	map<Node*,small_id> nodeToCcAg;
+	std::list<pair<small_id,Node*> > q;
+	q.emplace_back(root,node);
+	const pattern::Mixture::Agent* ag;
+	const Node* curr_node;
+	pair<small_id,Node*> next_node(0,nullptr);
+	while(!q.empty()){
+		ag = &ptrn.getAgent(q.front().first);
+		curr_node = q.front().second;
+		if(ag->getId() != curr_node->getId())
+			return false;
+		for(auto& site : *ag){
+			auto curr_int_state = curr_node->getInternalState(site.getId());
+			next_node.second = site.testMatch(curr_int_state,port_list,context);
+			if(next_node.second == nullptr)
+				return false;
+			if(next_node.second->getId() != short_id(-1)){//compare different pointers
+				next_node.first = ptrn.follow(q.front().first,site.getId()).first;
+				//need to check site of links?? TODO No
+				//if(next_node.first >= _cc.size())
+				//	return false;
+				if(nodeToCcAg.count(next_node.second) && nodeToCcAg[next_node.second] != next_node.first)
+					return false;
+				if(ccAgToNode[next_node.first]){
+					if(ccAgToNode[next_node.first] != next_node.second)
+						return false;
+				}
+				else {
+					q.emplace_back(next_node);
+					ccAgToNode[next_node.first] = next_node.second;//todo review
+					nodeToCcAg[next_node.second] = next_node.first;//todo review
+				}//next_node.second = nullptr;
+			}
+		}
+		ccAgToNode[q.front().first] = q.front().second;//case when agent mixture with no sites
+		nodeToCcAg[next_node.second] = next_node.first;//todo review
+		q.pop_front();
+	}
+	return true;
+	//} else throw False();//TODO check_aditional_edges???
+}
+
+CcInjection::~CcInjection(){};
+
+/*const vector<Node*>& CcInjection::getEmbedding() const {
+	return ccAgToNode;
+}*/
+
+bool CcInjection::codomain(vector<Node*>* injs,set<Node*>& cod) const {
+	int i = 0;
+	for(auto node_p : ccAgToNode){
+		if(cod.find(node_p) != cod.end())
+			return 2;//overlapped codomains
+		cod.emplace(node_p);
+		injs[0][i] = node_p;
+		i++;
+	}
+	return 0;
+}
+
+/*size_t CcInjection::count() const {
+	return ccAgToNode[0]->getCount();//TODO empty cc ??
+}*/
+
+Injection* CcInjection::clone(const map<Node*,Node*>& mask) const {
+	auto new_inj = new CcInjection(pattern());
+	new_inj->copy(this,mask);
+	return new_inj;
+}
+
+void CcInjection::copy(const CcInjection* inj,const map<Node*,Node*>& mask){
+	ccAgToNode.resize(inj->ccAgToNode.size());
+	for(size_t i = 0; i < ccAgToNode.size(); i++){
+		ccAgToNode[i] = (mask.at(inj->ccAgToNode[i]));//safe
+	}
+}
+
+bool CcInjection::operator==(const Injection& inj) const{
+	auto& cc_inj = static_cast<const CcInjection&>(inj);
+	if(&ptrn != &inj.pattern())
+		return false;
+	for(size_t i = 0;i < ccAgToNode.size(); i++)
+		if(ccAgToNode[i] != cc_inj.ccAgToNode[i])
+			return false;
+	return true;
+}
+
+
+/********** CcValueInj *******************/
+
+
+
+
+} /* namespace matching */

--- a/src/matching/CcInjection.h
+++ b/src/matching/CcInjection.h
@@ -1,0 +1,106 @@
+/*
+ * CcInjection.h
+ *
+ *  Created on: Oct 7, 2021
+ *      Author: naxo
+ */
+
+#ifndef SRC_MATCHING_CCINJECTION_H_
+#define SRC_MATCHING_CCINJECTION_H_
+
+#include "Injection.h"
+#include "../state/Node.h"
+
+
+namespace matching {
+
+
+class CcInjection : public Injection {
+	//friend class InjRandSet;
+	//map<small_id,big_id> ccAgToNode;//unordered
+	vector<Node*> ccAgToNode;
+	//const pattern::Mixture::Component& cc;//cc_id
+
+public:
+	//CcInjection(const pattern::Pattern& _cc);
+	CcInjection(const pattern::Pattern& _cc);
+	Injection* clone(const map<Node*,Node*>& mask) const override;
+	void copy(const CcInjection* inj,const map<Node*,Node*>& mask);
+	~CcInjection();
+
+	bool reuse(const simulation::SimContext& context,Node* node,
+			map<int,InjSet*>& port_list,small_id root = 0);
+
+	inline const vector<Node*>* getEmbedding() const override {
+		return &ccAgToNode;
+	}
+
+	bool codomain(vector<Node*>* injs,set<Node*>& cod) const override;
+
+	inline size_t count() const override {
+		return ccAgToNode[0]->getCount();
+	}
+
+	bool operator==(const Injection& inj) const override;
+};
+
+
+
+
+
+class CcValueInj : public CcInjection {
+	map<distribution_tree::DistributionTree<CcValueInj>*,int> containers;//TODO try with unordered_map
+	//FL_TYPE value;
+public:
+	CcValueInj(const pattern::Pattern::Component& _cc);
+	CcValueInj(const CcInjection& inj);
+
+	void addContainer(distribution_tree::DistributionTree<CcValueInj>& cont,int addr);
+	void selfRemove();
+	//returns true if the containers list is empty
+	bool removeContainer(distribution_tree::DistributionTree<CcValueInj>& cont);
+
+};
+
+
+
+
+/************* CcValueInj Inlines ****************************/
+
+inline CcValueInj::CcValueInj(const pattern::Pattern::Component& _cc) : CcInjection(_cc) {}
+
+inline CcValueInj::CcValueInj(const CcInjection& inj) : CcInjection(inj) {};
+
+inline void CcValueInj::addContainer(distribution_tree::DistributionTree<CcValueInj>& cont,int address){
+	containers[&cont] = address;this->address++;
+}
+
+inline bool CcValueInj::removeContainer(distribution_tree::DistributionTree<CcValueInj>& cont){
+	containers.erase(&cont);address--;
+	return containers.empty();
+}
+
+inline void CcValueInj::selfRemove(){
+	for(auto cont_addr : containers){
+		auto inj = cont_addr.first->erase(cont_addr.second);//TODO this will delete cont, check iterator invalidation
+#ifdef DEBUG
+		if(this != inj)
+			throw invalid_argument("erasing another inj (CcValueInj::selfRemove())");
+#endif
+	}
+	containers.clear();//is mandatory!
+}
+
+
+
+
+
+/*namespace distribution_tree{
+	template <typename T>
+	class DistributionTree<T>;
+}*/
+
+
+} /* namespace matching */
+
+#endif /* SRC_MATCHING_CCINJECTION_H_ */

--- a/src/matching/Injection.cpp
+++ b/src/matching/Injection.cpp
@@ -17,111 +17,35 @@
 namespace matching {
 
 
-/********** CcInjection **********/
 
-CcInjection::CcInjection(const pattern::Pattern& _cc) : Injection(_cc) {};
+/********** MixInjection *****************/
 
-CcInjection::CcInjection(const pattern::Pattern::Component& _cc)
-		: Injection(_cc),ccAgToNode(_cc.size(),nullptr) {
-	//reuse(_cc,node,port_list,root);
+MixInjection::MixInjection(const Injection* inj1,const Injection* inj2,const pattern::Mixture& m) :
+	Injection(m),ccInjs{inj1,inj2},distance(m.getRadius()){
+	//rev(&m.getComponent(0).getId() < &m.getComponent(1).getId() ? true : false){
+	/*if(rev){
+		ccInjs[0] = inj2;
+		ccInjs[1] = inj1;
+	}*/
+	emb[0] = *ccInjs[0]->getEmbedding();
+	emb[1] = *ccInjs[1]->getEmbedding();
+		//throw invalid_argument("MixInjection(): patterns should be sorted.");
 }
 
-bool CcInjection::reuse(const pattern::Pattern::Component& _cc,Node& node,
-		map<int,InjSet*>& port_list, const simulation::SimContext& context,small_id root) {
-	//ccAgToNode.clear();
-	for(auto& n : ccAgToNode)
-		n = nullptr;
-	//if(_cc.getAgent(root).getId() == node.getId()){
-	ccAgToNode.resize(_cc.size(),nullptr);
-	map<Node*,small_id> nodeToCcAg;
-	std::list<pair<small_id,Node*> > q;
-	q.emplace_back(root,&node);
-	const pattern::Mixture::Agent* ag;
-	const Node* curr_node;
-	pair<small_id,Node*> next_node(0,nullptr);
-	while(!q.empty()){
-		ag = &_cc.getAgent(q.front().first);
-		curr_node = q.front().second;
-		if(ag->getId() != curr_node->getId())
-			return false;
-		for(auto& site : *ag){
-			auto curr_int_state = curr_node->getInternalState(site.getId());
-			next_node.second = site.testMatch(curr_int_state,port_list,context);
-			if(next_node.second == nullptr)
-				return false;
-			if(next_node.second->getId() != short_id(-1)){//compare different pointers
-				next_node.first = _cc.follow(q.front().first,site.getId()).first;
-				//need to check site of links?? TODO No
-				//if(next_node.first >= _cc.size())
-				//	return false;
-				if(nodeToCcAg.count(next_node.second) && nodeToCcAg[next_node.second] != next_node.first)
-					return false;
-				if(ccAgToNode[next_node.first]){
-					if(ccAgToNode[next_node.first] != next_node.second)
-						return false;
-				}
-				else {
-					q.emplace_back(next_node);
-					ccAgToNode[next_node.first] = next_node.second;//todo review
-					nodeToCcAg[next_node.second] = next_node.first;//todo review
-				}//next_node.second = nullptr;
-			}
-		}
-		ccAgToNode[q.front().first] = q.front().second;//case when agent mixture with no sites
-		nodeToCcAg[next_node.second] = next_node.first;//todo review
-		q.pop_front();
-	}
-	return true;
-	//} else throw False();//TODO check_aditional_edges???
+Injection* MixInjection::clone(const map<Node*,Node*>& mask) const {
+	return nullptr;
 }
-
-CcInjection::~CcInjection(){};
-
-const vector<Node*>& CcInjection::getEmbedding() const {
-	return ccAgToNode;
-}
-
-void CcInjection::codomain(vector<Node*>& injs,set<Node*>& cod) const {
-	int i = 0;
-	for(auto node_p : ccAgToNode){
-		if(cod.find(node_p) != cod.end())
-			throw False();//TODO do not throw
-		cod.emplace(node_p);
-		injs[i] = node_p;
-		i++;
-	}
-}
-
-size_t CcInjection::count() const {
-	return ccAgToNode[0]->getCount();//TODO empty cc ??
+void MixInjection::copy(const MixInjection* inj,const map<Node*,Node*>& mask){
+	throw invalid_argument("cannot copy mix injection.");
 }
 
 
-Injection* CcInjection::clone(const map<Node*,Node*>& mask) const {
-	auto new_inj = new CcInjection(pattern());
-	new_inj->copy(this,mask);
-	return new_inj;
+bool MixInjection::operator==(const Injection& inj) const {
+	auto& mix_inj = static_cast<const MixInjection&>(inj);
+	if(ccInjs[0] == mix_inj.ccInjs[0] && ccInjs[1] == mix_inj.ccInjs[1])
+		return true;
+	return false;
 }
-
-void CcInjection::copy(const CcInjection* inj,const map<Node*,Node*>& mask){
-	ccAgToNode.resize(inj->ccAgToNode.size());
-	for(size_t i = 0; i < ccAgToNode.size(); i++){
-		ccAgToNode[i] = (mask.at(inj->ccAgToNode[i]));//safe
-	}
-}
-
-bool CcInjection::operator==(const Injection& inj) const{
-	auto& cc_inj = static_cast<const CcInjection&>(inj);
-	if(&ptrn != &inj.pattern())
-		return false;
-	for(size_t i = 0;i < ccAgToNode.size(); i++)
-		if(ccAgToNode[i] != cc_inj.ccAgToNode[i])
-			return false;
-	return true;
-}
-
-
-/********** CcValueInj *******************/
 
 
 

--- a/src/pattern/mixture/Agent.cpp
+++ b/src/pattern/mixture/Agent.cpp
@@ -20,12 +20,12 @@ Pattern::Agent::~Agent(){};
 
 
 const Pattern::Site& Pattern::Agent::addSite(Site* site){
-	if(interface.count(*site))
+	auto it_ins = interface.emplace(*site);
+	if(!it_ins.second)
 		throw SemanticError("The site is already declared in this Agent.",yy::location());
-	auto& new_site = *interface.emplace(*site).first;
 	site->id = -1;
 	delete site;
-	return new_site;
+	return *it_ins.first;
 }
 
 const Pattern::Site& Pattern::Agent::getSite(Site* site) {
@@ -690,7 +690,7 @@ string Pattern::Site::toString(small_id sign_id, small_id ag_pos,
 		out += "!*";
 		break;
 	case LinkType::WILD :
-		//if(sign.getType() & Signature::Site::BIND)
+		if(sign.getType() & Signature::Site::BIND)
 			out += "?";
 		break;
 	}

--- a/src/pattern/mixture/Agent.h
+++ b/src/pattern/mixture/Agent.h
@@ -10,7 +10,7 @@
 
 #include "Pattern.h"
 #include "../../grammar/location.hh"
-#include "../../matching/Injection.h"
+//#include "../../matching/Injection.h"
 #include "../Action.h"
 
 
@@ -18,13 +18,17 @@ namespace state {
 class Node;
 class InternalState;
 }
-
+namespace matching {
+class Injection;
+class InjSet;
+}
 namespace pattern {
 
 class Environment;
 
 using InjSet = matching::InjSet;
 
+//typedef set<matching::Injection*> InjSet;
 
 
 

--- a/src/pattern/mixture/Component.cpp
+++ b/src/pattern/mixture/Component.cpp
@@ -172,7 +172,7 @@ const list<pair<const simulation::Rule&,small_id>>& Pattern::Component::getRateD
 	return deps;
 }
 
-string Pattern::Component::toString(const Environment& env) const {
+string Pattern::Component::toString(const Environment& env,int mark) const {
 	string out, glue = ",";
 
 	// put labels to bindings
@@ -194,6 +194,8 @@ string Pattern::Component::toString(const Environment& env) const {
 	}
 
 	for( unsigned mixAgId = 0; mixAgId < agents.size(); mixAgId++ ) {
+		if(mark == mixAgId)
+			out += "*";
 		out += (agents[mixAgId])->toString(env, mixAgId, bindLabels ) + glue;
 		bindLabel++;
 	}

--- a/src/pattern/mixture/Component.h
+++ b/src/pattern/mixture/Component.h
@@ -51,7 +51,7 @@ public:
 
 	//vector<small_id> setGraph();
 	const map<ag_st_id,ag_st_id>& getGraph() const;
-	string toString(const Environment& env) const;
+	string toString(const Environment& env,int mark = -1) const;
 
 	const Agent& getAgent(small_id ag_id ) const override;
 

--- a/src/pattern/mixture/Pattern.h
+++ b/src/pattern/mixture/Pattern.h
@@ -65,7 +65,8 @@ public:
 	virtual void addInclude(small_id id){
 		includes.emplace(id);
 	}
-	virtual string toString(const Environment& env) const = 0;
+	virtual ag_st_id follow(small_id ag_id,small_id site) const = 0;
+	virtual string toString(const Environment& env,int mark = -1) const = 0;
 };
 
 class Mixture;

--- a/src/simulation/Parameters.cpp
+++ b/src/simulation/Parameters.cpp
@@ -24,7 +24,9 @@ Parameters::Parameters() : options(nullptr),outputFile("sim"),outputFileType("ts
 #endif
 }
 
-void Parameters::makeOptions(const string &msg){
+void Parameters::makeOptions(const string &v,const string &u,const string &msg){
+	version = v;
+	usage = u;
 	options = new options_description(msg);
 
 	//allowed options
@@ -67,7 +69,11 @@ void Parameters::evalOptions(int argc, char* argv[]){
 	}
 
 	if (vm.count("help")) {
-		cout << *options << "\n";
+		cout << version << "\n" << usage << "\n\n" << *options << "\n";
+		exit(0);
+	}
+	else if(vm.count("version")){
+		cout << version << endl;
 		exit(0);
 	}
 

--- a/src/simulation/Parameters.h
+++ b/src/simulation/Parameters.h
@@ -42,13 +42,15 @@ class Parameters {
 	Parameters();
 	/** \brief Constructs the boost::option_description object to evaluate program arguments.
 	 */
-	void makeOptions(const string &msg);
+	void makeOptions(const string &v,const string &u,const string &msg);
 
 	/** \brief Set simulation parameters from arguments vector.
 	 */
 	void evalOptions(int argc, char* argv[]);
 public:
 	options_description *options;	//!< boost object to manipulate program options. Created on makeOptions() call.
+
+	string version,usage;
 
 	vector<string> inputFiles;		//!< Kappa files of the the model.
 	string outputFile;				//!< Output file name. Default is "output". PExKa will add a simulation number if needed.

--- a/src/simulation/Plot.cpp
+++ b/src/simulation/Plot.cpp
@@ -109,6 +109,17 @@ void EventPlot::fill(const state::State& state,const pattern::Environment& env) 
 		//cout << endl;
 		nextPoint += dE;
 	}
+	if(state.isDone() && e > (nextPoint-dE)){
+		file << state.getCounter().getTime();
+		//cout << state.getSim().getId() <<"]\t" << nextPoint;
+		for(auto var : env.getObservables()){
+			file << "\t" << state.getVarValue(var->getId());
+			//cout << "\t" << state.getVarValue(var->getId(), aux_map);
+		}
+		file << endl;
+		//cout << endl;
+		nextPoint += dE;
+	}
 }
 
 void EventPlot::fillBefore(const state::State& state,const pattern::Environment& env) {

--- a/src/simulation/Rule.h
+++ b/src/simulation/Rule.h
@@ -19,9 +19,9 @@
 
 //class pattern::Environment;
 
-namespace matching {
-	class InjRandTree;
-}
+/*namespace matching {
+template <typename T> class InjRandTree;
+}*/
 
 
 namespace simulation {
@@ -83,6 +83,7 @@ protected:
 	pair<const BaseExpression*,int> unaryRate;//rate,radius
 	//BaseExpression::Reduction basic,unary;
 	list<Action> script;
+	int bindCount;
 	small_id matchCount;		///< counter of lhs agents paired with rhs agents
 	vector<state::Node*> newNodes;
 	CandidateMap influence;
@@ -104,26 +105,28 @@ public:
 	const Mixture& getRHS() const;
 	const BaseExpression& getRate() const;
 //	const BaseExpression::Reduction& getReduction() const;
-	const BaseExpression& getUnaryRate() const;
+	const pair<const BaseExpression*,int>& getUnaryRate() const;
 //	const BaseExpression::Reduction& getUnaryReduction() const;
 	const CandidateMap& getInfluences() const;
 	const list<pair<unsigned,const BaseExpression*> > getTokenChanges() const;
+	int getBindCount() const {
+		return bindCount;
+	}
 
 	//two<FL_TYPE> evalActivity(const matching::InjRandContainer* const * injs,const VarVector& vars) const;
 
 	/** \brief Set RHS of the rule.
 	 * If this is a reversible rule, mix is declared in env and should not be
-	 * freed by rule destructor.
-	 */
+	 * freed by rule destructor.				*/
 	void setRHS(Mixture* mix,bool is_declared = false);
+
 	/** \brief Set basic rate for the rule.
-	 * @param r basic rate of the rule.
-	 */
+	 * @param r basic rate of the rule.			*/
 	void setRate(const BaseExpression* r);
+
 	/** \brief Set the unary rate for the rule.
 	 * @param u_rate pair of (rate,radius) for unary instances of a binary rule.
-	 * @param Radius indicate the range of search for connectivity.
-	 */
+	 * @param Radius indicate the range of search for connectivity.		*/
 	void setUnaryRate(pair<const BaseExpression*,int> u_rate = make_pair(nullptr,0));
 
 	/** \brief Calculate actions to apply using the difference between LHS and RHS.
@@ -134,8 +137,7 @@ public:
 	 * @param env the environment of the simulation.
 	 * @param lhs_order initial order of LHS agents (obtained from Mixture::declare()).
 	 * @param rhs_order initial order of RHS agents.
-	 * @param consts to evaluate const-expressions.
-	 */
+	 * @param consts to evaluate const-expressions.			*/
 	void difference(const Environment& env,const SimContext &context);
 
 	void addTokenChange(pair<unsigned,const BaseExpression*> tok);

--- a/src/simulation/SimContext.h
+++ b/src/simulation/SimContext.h
@@ -19,12 +19,18 @@ template <typename T> class Auxiliar;
 }
 
 namespace matching {
+template <typename T>
 class InjRandContainer;
+class CcInjection;
+class MixInjection;
 }
+
+typedef matching::InjRandContainer<matching::CcInjection> CcInjRandContainer;
+typedef matching::InjRandContainer<matching::MixInjection> MixInjRandContainer;
 
 namespace simulation {
 
-
+using namespace std;
 
 class SimContext {
 protected:
@@ -100,11 +106,17 @@ public:
 		return FL_TYPE(0.0);
 	}
 
-	virtual matching::InjRandContainer& getInjContainer(int cc_id) {
+	virtual CcInjRandContainer& getInjContainer(int cc_id) {
 		throw invalid_argument("SimContext::getInjContainer(): invalid context.");
 	}
-	virtual const matching::InjRandContainer& getInjContainer(int cc_id) const {
+	virtual const CcInjRandContainer& getInjContainer(int cc_id) const {
 		throw invalid_argument("SimContext::getInjContainer(): invalid context.");
+	}
+	virtual MixInjRandContainer& getMixInjContainer(int cc_id) {
+		throw invalid_argument("SimContext::getMixInjContainer(): invalid context.");
+	}
+	virtual const MixInjRandContainer& getMixInjContainer(int cc_id) const {
+		throw invalid_argument("SimContext::getMixInjContainer(): invalid context.");
 	}
 	virtual FL_TYPE getTokenValue(unsigned id) const {
 		throw invalid_argument("SimContext::getTokenValue(): invalid context.");

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -86,6 +86,7 @@ void Simulation::initialize(const vector<list<unsigned int>>& _cells,grammar::as
 		//env.buildInfluenceMap(id_state.second);
 		//id_state.second.buildInfluenceMap();
 		id_state.second.initInjections();
+		id_state.second.initUnaryInjections();
 		id_state.second.initActTree();
 	}
 }
@@ -104,8 +105,10 @@ void Simulation::run(const Parameters& params){
 			id_state.second.updateDeps(pattern::Dependency());
 		}
 		done = true;
-		for(auto& id_state : cells)
+		for(auto& id_state : cells){
 			id_state.second.tryPerturbate();
+			id_state.second.plotOut();
+		}
 #ifdef DEBUG
 		if(params.verbose > 0 && id == 0){
 			cout << "=== Final-State ";

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -72,7 +72,7 @@ public:
 	static vector<list<unsigned int> > allocCells(int n_cpus, const vector<double> &w_vertex,
 			const map<pair<int,int>,double> &w_edges, int tol);
 
-	bool isDone() const;
+	bool isDone() const override;
 
 	void print() const;
 

--- a/src/state/SiteGraph.cpp
+++ b/src/state/SiteGraph.cpp
@@ -136,6 +136,60 @@ vector<Node*>::const_iterator SiteGraph::end() const {
 	return container.cend();
 }
 
+void SiteGraph::neighborhood(map<int,list<Node*>>& nb,set<Node*>& visited,
+		int radius,function<bool(Node*,int)>* filter) const {
+	//radius -> nodes
+	list<Node*> to_visit(nb[0]);
+	if(filter)
+		for(auto node : to_visit){
+			if((*filter)(node,0))
+				nb[0].emplace_back(node);
+			visited.emplace(node);
+		}
+	else
+		visited.insert(to_visit.begin(),to_visit.end());
+	for(int r = 0; r < radius; r++){
+		if(nb.count(r) == 0)
+			return;
+		int n = to_visit.size();
+		for(int i = 0; i < n;i++){
+			auto node = to_visit.front();
+			to_visit.pop_front();
+			for(auto site : *node){
+				auto target_node = site->getLink().first;
+				if(target_node && visited.emplace(target_node).second){
+					to_visit.emplace_back(target_node);
+					if(!(filter && (*filter)(target_node,r+1)))
+						nb[r+1].emplace_back(target_node);	//only if no filter or filter(node) = true
+				}
+			}
+		}
+	}
+}
+
+bool SiteGraph::areConnected(list<Node*> &to_visit,
+		set<Node*>& to_find,int max_dist) const {
+	set<Node*> visited(to_visit.begin(),to_visit.end());
+	while(!to_visit.empty() && max_dist){
+		int n = to_visit.size();
+		while(n--){
+			auto node = to_visit.front();
+			to_visit.pop_front();
+			for(auto site : *node){
+				auto target_node = site->getLink().first;
+				if(target_node){
+					if(to_find.count(target_node))
+						return true;
+					else if(visited.emplace(target_node).second)
+						to_visit.emplace_back(target_node);
+				}
+			}
+		}
+		max_dist--;
+	}
+	return false;
+}
+
 void SiteGraph::print(const pattern::Environment& env) const {
 	cout << "StateGraph[" << getPopulation() << "]";
 	big_id nodes_to_show = std::min<big_id>(simulation::Parameters::get().showNodes,container.size());

--- a/src/state/SiteGraph.h
+++ b/src/state/SiteGraph.h
@@ -11,6 +11,7 @@
 #include <utility> //pair
 #include <list>
 #include <vector>
+#include <functional>
 #include "Node.h"
 #include "../util/params.h"
 #include "../expressions/AlgExpression.h"
@@ -60,6 +61,35 @@ public:
 	size_t getPopulation() const;
 	void decPopulation(size_t pop = 1);
 
+	/*void neighbourhood(map<int,list<Node*>>& nb, int radius = 1000) const {
+		nb[0].insert(nb[0].begin(),visited.begin(),visited.end());
+	}*/
+	/** \brief Explore the neighborhood of nodes.
+	 *
+	 * Starting from nbh[0] node-list, visit every node in their neighborhood
+	 * and stores them once in nbh[distance] lists.
+	 * @param nbh Mapping of the NBH as distance -> node list. Used as input and output.
+	 * @param visited set of nodes to avoid visiting (filled as output).
+	 * @param radius the max distance to look for nodes.
+	 * @param filter function to avoid insert a node when true.	 */
+	void neighborhood(map<int,list<Node*>>& nbh,set<Node*>& visited, int radius = 1000,
+			function<bool(Node*,int)>* filter = nullptr) const;
+	bool areConnected(const vector<Node*> &emb1,const vector<Node*> &emb2,int max_dist) const {
+		list<Node*> to_visit;
+		set<Node*> to_find;
+		for(auto node : emb1){
+			if(node == nullptr)
+				break;
+			to_visit.emplace_back(node);
+		}
+		for(auto node : emb2){
+			if(node == nullptr)
+				break;
+			to_find.emplace(node);
+		}
+		return areConnected(to_visit,to_find,max_dist);
+	}
+	bool areConnected(list<Node*> &to_visit,set<Node*>& to_find,int max_dist) const;
 	void print(const pattern::Environment& env) const;
 
 

--- a/src/state/State.cpp
+++ b/src/state/State.cpp
@@ -10,6 +10,7 @@
 #include "../matching/Injection.h"
 #include "../matching/InjRandSet.h"
 #include "../data_structs/MyMaskedBinaryRandomTree.h"
+#include "../data_structs/SimpleTree.h"
 #include "../simulation/Plot.h"
 
 #include "../pattern/mixture/Component.h"
@@ -19,6 +20,7 @@
 
 namespace state {
 using Deps = pattern::Dependency::Dep;
+using namespace matching;
 
 State::State(int id,simulation::Simulation& _sim,
 	const BaseExpression& vol,simulation::Plot& _plot) :
@@ -171,10 +173,9 @@ void State::apply(const simulation::Rule& r){
 	}
 }
 
-void State::positiveUpdate(const simulation::Rule::CandidateMap& wake_up){
+void State::positiveUpdate(const Rule::CandidateMap& wake_up){
 	//TODO vars_to_wake_up
-	//auto& wake_up = r.getInfluences();
-	int new_injs = 0;
+	//auto& wake_up = rule.getInfluences();
 	for(auto& key_info : wake_up){
 		auto key = key_info.first;
 		auto info = key_info.second;
@@ -184,60 +185,165 @@ void State::positiveUpdate(const simulation::Rule::CandidateMap& wake_up){
 		//	continue;	//every action applied to node is null
 		map<int,matching::InjSet*> port_list;
 		auto inj_p = injections[key.cc->getId()]->
-				emplace(*node,port_list,*this,key.match_root.first);
+				emplace(*this,node,port_list,key.match_root.first);
 
 		if(inj_p){
 #ifdef DEBUG
 			if(simulation::Parameters::get().verbose > 3){
-				if(new_injs == 0)
+				if(ev.new_injs.size() == 0)
 					cout << "New injections found:\n";
 				cout << "\tPattern " << inj_p->pattern().toString(env) << " matches with agents IDs ";
-				for(auto& node : inj_p->getEmbedding())
+				for(auto& node : *inj_p->getEmbedding())
 					cout << node->getAddress() << ",";
 				cout << endl;
-				new_injs++;
 			}
 #endif
+			ev.new_injs.push_back(inj_p);
 			for(;nulls.first != nulls.second;++nulls.first)
 				port_list.erase(nulls.first->second);
-			if(port_list.empty())//TODO check cc.size()
-				node->addDep(inj_p);
-			else
-				for(auto port : port_list)
-					port.second->emplace(inj_p);
+			//TODO? check cc.size()
+			node->addDep(inj_p);
+			for(auto port : port_list)
+				port.second->emplace(inj_p);
 			//cout << "matching Node " << node_p->toString(env) << " with CC " << comp.toString(env) << endl;
 			ev.to_update.emplace(key.cc);
 			updateDeps(pattern::Dependency(Deps::KAPPA,key.cc->getId()));
 		}
 	}
-	for(auto side_eff : ev.side_effects){//trying to create injection for side-effects
+	/*for(auto side_eff : ev.side_effects){//trying to create injection for side-effects
 		for(auto& cc_ag : env.getFreeSiteCC(side_eff.first->getId(),side_eff.second)){
 			map<int,matching::InjSet*> port_list;
-			auto inj_p = injections[cc_ag.first->getId()]->emplace(*side_eff.first,port_list,*this,cc_ag.second);
+			auto inj_p = injections[cc_ag.first->getId()]->emplace(*this,side_eff.first,port_list,cc_ag.second);
 			if(inj_p){
-				if(port_list.empty())
-					side_eff.first->addDep(inj_p);
-				else{
-					for(auto port : port_list)
-						port.second->emplace(inj_p);
-				}
+				side_eff.first->addDep(inj_p);
+				for(auto port : port_list)
+					port.second->emplace(inj_p);
 				ev.to_update.emplace(cc_ag.first);
 			}
 		}
-	}
+	}*/
+}
 
-	//prepare negative_update
+void State::nonLocalUpdate(const simulation::Rule& rule,
+		const list<matching::Injection*>& new_injs) {
+	auto& unary_cc = env.getUnaryCCs();
+	auto& unary_mixts = env.getUnaryMixtures();
+	auto script_it = rule.getScript().rbegin();
+	int max_dist = env.getMaxRadius() - 1;
+	map<int,list<Node*>> nbh1,nbh2;
+	set<Node*> nbh_set1,nbh_set2;
+	map<Injection*,int> injs1,injs2,*injs_ptr(nullptr);
+	function<bool(Node*,int)> filter = [&] (Node* node,int d){
+		for(auto inj : node->getLifts())
+			if(unary_cc.find(inj->pattern().getId()) != unary_cc.end())
+				injs_ptr->emplace(inj,d);
+		return false;
+	};
+	//possible new unary injections caused by binds
+	for(int i = 0; i < rule.getBindCount(); i++){
+		auto cc_ag = script_it->trgt_ag;
+		auto node1 = ev.emb[cc_ag.first][cc_ag.second];
+		cc_ag = script_it->chain->trgt_ag;
+		auto node2 = ev.emb[cc_ag.first][cc_ag.second];
+		nbh1[0].emplace_back(node1);
+		nbh_set1.emplace(node2);
+		injs_ptr = &injs1;
+		graph.neighborhood(nbh1,nbh_set1,max_dist,&filter);
+		nbh2[0].emplace_back(node2);
+		nbh_set2.emplace(node1);
+		injs_ptr = &injs2;
+		graph.neighborhood(nbh2,nbh_set2,max_dist,&filter);//TODO this filter can be more specific
+
+		script_it++;
+		for(auto inj1_r : injs1){
+			auto inj1 = inj1_r.first;
+			for(auto inj2_r : injs2){//TODO iterate in the other way?
+				auto inj2 = inj2_r.first;
+				if(inj1 == inj2)
+					continue;
+				pair<int,int> key(inj1->pattern().getId(),inj2->pattern().getId());
+				auto umix_it = unary_mixts.find(key);
+				if(umix_it != unary_mixts.end()){
+					auto& umix = umix_it->second;
+					int dist = inj1_r.second + inj2_r.second+1;
+					IF_DEBUG_LVL(0,if(dist < 0) throw invalid_argument("State::nonLocalUpdate(): r < 0!");)
+					/*for(auto r_mix : umix){
+						if(r_mix.first < dist)
+							break;*/
+					if(umix.back().first < dist)
+						continue;
+					auto mix_id = umix.front().second;
+					auto mix = env.getMixtures()[mix_id];
+					IF_DEBUG_LVL(2,cout << "New unary injection of "
+							<< mix->toString(env) <<" found: "
+							<< inj1->getEmbedding()[0][0]->getAddress() << ","
+							<< inj2->getEmbedding()[0][0]->getAddress() << endl;)
+					if(inj1->pattern().getId() < inj2->pattern().getId())
+						nlInjections.at(mix_id)->emplace(*this,inj1,inj2,dist);
+					else
+						nlInjections.at(mix_id)->emplace(*this,inj2,inj1,dist);
+					ev.to_update.emplace(mix);
+				}
+			}
+		}
+	}
+	//TODO new unary inj from new injs
+
+	nbh1.clear();
+	nbh2.clear();
+	nbh_set1.clear();
+	nbh_set2.clear();
+	map<Injection*,two<int>> injs_map2;
+	int cc_id;
+	function<bool(Node*,int)> filter2 = [&] (Node* node,int d){
+		for(auto inj : node->getLifts()){
+			auto unmix_it = unary_mixts.find(make_pair(cc_id,inj->pattern().getId()));
+			if(unmix_it != unary_mixts.end() && unmix_it->second.back().first >= d)
+				injs_map2.emplace(inj,make_pair(d,unmix_it->second.front().second));
+		}
+		return false;
+	};
+	for(auto new_inj : new_injs){
+		cc_id = new_inj->pattern().getId();
+		auto uncc_it = unary_cc.find(cc_id);
+		if(uncc_it != unary_cc.end()){
+			auto& emb = *new_inj->getEmbedding();
+			auto& target_ccs = uncc_it->second;
+			nbh1.emplace(piecewise_construct,forward_as_tuple(0),
+					forward_as_tuple(emb.begin(),emb.end()));
+			graph.neighborhood(nbh1,nbh_set1,target_ccs.back().first,&filter2);
+			for(auto inj_dist_rid : injs_map2){
+				auto inj2 = inj_dist_rid.first;
+				if(inj2 == new_inj)
+					continue;
+				auto mix = env.getMixtures()[inj_dist_rid.second.second];
+				IF_DEBUG_LVL(2,cout << "New unary injection of "
+						<< mix->toString(env) <<" found: "
+						<< new_inj->getEmbedding()[0][0]->getAddress() << ","
+						<< inj2->getEmbedding()[0][0]->getAddress() << endl;)
+				if(new_inj->pattern().getId() < inj2->pattern().getId())
+					nlInjections.at(inj_dist_rid.second.second)->emplace(*this,new_inj,inj2,inj_dist_rid.second.first);
+				else
+					nlInjections.at(inj_dist_rid.second.second)->emplace(*this,inj2,new_inj,inj_dist_rid.second.first);
+				ev.to_update.emplace(mix);
+
+			}
+		}
+	}
+}
+
+void State::activityUpdate(){
+	//prepare positive_update
 	//set<small_id> rule_ids;
-	for(auto cc : ev.to_update){
-		for(auto r_id : cc->includedIn())
+	for(auto ptrn : ev.to_update){
+		for(auto r_id : ptrn->includedIn())
 			ev.rule_ids.emplace(r_id);
 	}
 	//total update
 	//cout << "rules to update: ";
 	for(auto r_id : ev.rule_ids){
 		//cout << env.getRules()[r_id].getName() << ", ";
-		auto act = rates[r_id]->evalActivity(*this);
-		activityTree->add(r_id,act.first+act.second);
+		updateActivity(r_id);
 	}
 	//cout << endl;
 	counter.incNullActions(ev.null_actions.size());
@@ -266,8 +372,9 @@ void State::advanceUntil(FL_TYPE sync_t,UINT_TYPE max_e) {
 			#endif
 			counter.incNullEvents(ex.error);
 		}
+		activityUpdate();
 #ifdef DEBUG
-		if(counter.getEvent() % 10 == 0 && simulation::Parameters::get().verbose > 3){
+		if((counter.getEvent()+counter.getNullEvent()) % 10 == 0 && simulation::Parameters::get().verbose > 3){
 			cout << "---------------------------------------------\n";
 			this->print();
 			cout << "---------------------------------------------\n";
@@ -285,26 +392,65 @@ void State::selectBinaryInj(const simulation::Rule& r,bool clsh_if_un) const {
 	//ev->emb = new Node**[mix.compsCount()];
 	auto& mix = r.getLHS();
 	ev.cc_count = mix.compsCount();
+#ifdef DEBUG
+	if(simulation::Parameters::get().verbose > 1)
+		cout << " (binary) | Root-nodes: ";
+#endif
 	for(unsigned i = 0 ; i < mix.compsCount() ; i++){
 		auto& cc = mix.getComponent(i);
 		injections[cc.getId()]->selectRule(r.getId(), i);
 		auto& inj = injections[cc.getId()]->chooseRandom(rng);
-		try{
-			inj.codomain(ev.emb[i],total_cod);
-		}
-		catch(False& ex){
-			throw NullEvent(2);//overlapped codomains
-		}
+#ifdef DEBUG
+		if(simulation::Parameters::get().verbose > 1)
+			cout << inj.getEmbedding()[0][0]->getAddress() << ",";
+#endif
+		if(inj.codomain(&ev.emb[i],total_cod))
+			throw NullEvent(3);//overlapped codomains
+	}
+	IF_DEBUG_LVL(2,cout << endl)
+	if(clsh_if_un && graph.areConnected(ev.emb[0],ev.emb[1],r.getUnaryRate().second)){
+		throw NullEvent(2);//selected instance is not binary
 	}
 	//static MixEmbMap<expressions::Auxiliar,FL_TYPE,Node> mix_map;
-	ev.mix_map.setEmb(ev.emb);
-	//if(clsh_if_un)
-	//	return;//TODO
+	ev.mix_map.clear();
+	for(auto& aux_rf : mix.getAuxCoords())
+		ev.mix_map[aux_rf.first] = ev.emb[aux_rf.second.cc_pos][aux_rf.second.ag_pos]
+				/*Node*/->getInternalValue(aux_rf.second.st_id).valueAs<FL_TYPE>();
 	this->setAuxMap(&ev.mix_map);
 	return;
 }
 
-void State::selectUnaryInj(const simulation::Rule& mix) const {
+
+void State::selectUnaryInj(const simulation::Rule& rule) const {
+	auto& mix = rule.getLHS();
+	auto& inj = nlInjections.at(mix.getId())->chooseRandom(rng);
+	set<Node*> total_cod;
+
+#ifdef DEBUG
+	if(simulation::Parameters::get().verbose > 1){
+		cout << " (unary)  | Root-nodes: " <<
+			 inj.getEmbedding()[0][0]->getAddress() << "," <<
+			 inj.getEmbedding()[1][0]->getAddress() << endl;
+
+	}
+#endif
+
+	if(inj.codomain(ev.emb,total_cod)){
+		nlInjections.at(mix.getId())->erase(&inj,*this);
+		ev.to_update.emplace(&mix);
+		throw NullEvent(3);
+	}
+	//TODO check-connex
+	//TODO clear nlInjections
+	ev.mix_map.clear();
+	for(auto& aux_rf : mix.getAuxCoords())
+		ev.mix_map[aux_rf.first] = ev.emb[aux_rf.second.cc_pos][aux_rf.second.ag_pos]
+				/*Node*/->getInternalValue(aux_rf.second.st_id).valueAs<FL_TYPE>();
+	this->setAuxMap(&ev.mix_map);
+	ev.is_unary = true;
+	//TODO delete if another way to erase unary-injection is implemented
+	nlInjections.at(mix.getId())->erase(&inj,*this);
+	ev.to_update.emplace(&mix);
 	return;
 }
 
@@ -312,7 +458,9 @@ void State::selectInjection(const simulation::Rule& r,two<FL_TYPE> bin_act,
 		two<FL_TYPE> un_act) {
 	//if mix.is empty TODO
 	//if mix.unary -> select_binary
-	if(std::isinf(bin_act.first)){
+	if(!r.getUnaryRate().first)
+		selectBinaryInj(r,false);
+	else if(std::isinf(bin_act.first)){
 		if(std::isinf(un_act.first)){
 			auto rd = uniform_int_distribution<int>(1)(rng);
 			if(rd)
@@ -341,10 +489,14 @@ const simulation::Rule& State::drawRule(){
 	auto rid_alpha = activityTree->chooseRandom();
 	auto& rule = env.getRules()[rid_alpha.first];
 
+#ifdef DEBUG
+	if(simulation::Parameters::get().verbose > 1)
+		printf( "  | Rule: %-11.11s",rule.getName().c_str());
+#endif
+
 	auto a1a2 = rates[rid_alpha.first]->evalActivity(*this);
 	auto alpha = a1a2.first + a1a2.second;
 
-	//*?
 	if(alpha == 0.)
 		activityTree->add(rid_alpha.first,0.);
 
@@ -353,9 +505,10 @@ const simulation::Rule& State::drawRule(){
 			//TODO if IntSet.mem rule_id state.silenced then (if !Parameter.debugModeOn then Debug.tag "Real activity is below approximation... but I knew it!") else invalid_arg "State.draw_rule: activity invariant violation"
 		}
 		auto rd = uniform_real_distribution<FL_TYPE>(0.0,1.0)(rng);
+		//auto rd = 0.95; //deterministic
 		if(rd > (alpha / rid_alpha.second) ){
 			activityTree->add(rid_alpha.first,alpha);
-			throw NullEvent(3);//TODO (Null_event 3)) (*null event because of over approximation of activity*)
+			throw NullEvent(4);//TODO (Null_event 4)) (*null event because of over approximation of activity*)
 		}
 	}
 	int radius = 0;//TODO
@@ -409,7 +562,7 @@ int State::event() {
 
 #ifdef DEBUG
 	if(simulation::Parameters::get().verbose > 1)
-		printf("Event %3lu | Time %.4f \t  act = %.4f",
+		printf("Event %3lu | Time %.4f | act = %.4f",
 				counter.getEvent(),counter.getTime(),act);
 #endif
 	//EventInfo* ev = nullptr;
@@ -418,19 +571,9 @@ int State::event() {
 	auto& rule = drawRule();
 	plot.fillBefore(*this,env);
 
-#ifdef DEBUG
-	if(simulation::Parameters::get().verbose > 1){
-		printf( "  | Rule: %-11.11s",rule.getName().c_str());
-		cout << "  Root-node: ";
-		for(int i = 0; i < ev.cc_count; i++)
-			cout << ev.emb[i][0]->getAddress() << ",";
-		cout << endl;
-		//printf("  Root-node: %03lu\n",(ev->cc_count ?
-		//		ev->emb[0][0]->getAddress() : -1L));
-	}
-#endif
 	apply(rule);
 	positiveUpdate(rule.getInfluences());
+	//nonLocalUpdate(rule,ev.new_injs);
 
 	return 0;
 }
@@ -518,39 +661,114 @@ void State::initInjections() {
 			delete injections[i];
 		delete[] injections;
 	}
-	injections = (matching::InjRandContainer**)(new matching::InjRandContainer*[env.size<pattern::Mixture::Component>()]);
+	injections = new CcInjRandContainer*[env.size<pattern::Mixture::Component>()];
 	for(auto cc : env.getComponents())
 		if(cc->getRateDeps().size()){
-			injections[cc->getId()] = new matching::InjRandTree(*cc,rates);
+			injections[cc->getId()] = new InjRandTree<CcInjection>(*cc,rates);
 			//try{
 			for(auto node_p : graph){
 				map<int,matching::InjSet*> port_list;
 				if(cc->getAgent(0).getId() != node_p->getId())//very little speed-up
 					continue;
 				//cout << comp.toString(env) << endl;
-				auto inj_p = injections[cc->getId()]->emplace(*node_p,port_list,*this);
+				auto inj_p = injections[cc->getId()]->emplace(*this,node_p,port_list);
 
 				if(inj_p){
-					if(port_list.empty())
-						node_p->addDep(inj_p);
-					else{
-						for(auto port : port_list)
-							port.second->emplace(inj_p);
-					}
+					//if(port_list.empty())
+					node_p->addDep(inj_p);
+					for(auto port : port_list)
+						port.second->emplace(inj_p);
 				}
 			}
 			//}catch(exception &e){
 			//	throw e;
 			//}
 		}
-		else
-			injections[cc->getId()] = new matching::InjLazyContainer(*cc,*this,graph,injections[cc->getId()]);
+		else	//inj-containers are initialized when need to be count (useful for perturbation mixes)
+			injections[cc->getId()] = new InjLazyContainer<CcInjection>(*cc,*this,graph,injections[cc->getId()]);
+}
+
+void State::initUnaryInjections(){
+	map<two<matching::Injection*>,int> unary_instances;
+	auto& unary_mixes = env.getUnaryMixtures();
+	auto& mixtures = env.getMixtures();
+	matching::InjRandSet<MixInjection>* inj_cont;
+	for(auto& un_mix : unary_mixes){
+		auto ccs = un_mix.first;
+		if(ccs.first > ccs.second )
+			continue;
+		//initializing lazy containers
+		injections[ccs.first]->count();
+		injections[ccs.second]->count();
+		int r = 0;
+		inj_cont = nullptr;
+		for(auto r_mix : un_mix.second){
+			if(r != r_mix.first){
+				inj_cont = new InjRandSet<MixInjection>(*mixtures[r_mix.second],inj_cont);
+				r = r_mix.first;
+			}
+			nlInjections[r_mix.second] = inj_cont;
+		}
+	}
+	for(auto& cc_cc : env.getUnaryCCs()){
+		bool rev = false;
+		for(auto ccc : cc_cc.second)
+			if(ccc.second < cc_cc.first)
+				rev = true; /// TODO break for speed-up
+		if(rev)
+			continue;
+		auto cc = env.getComponents()[cc_cc.first];
+		auto& cc_candidates = cc_cc.second;
+		//tests if theres an injection of a cc_candidate in inj neighborhood
+		auto test = [&] (const Injection* inj) -> void {
+			auto emb = inj->getEmbedding()[0];
+			set<Node*> visited;
+			map<int,list<Node*>> nb;
+			auto& start = nb[0];
+			start.insert(start.begin(),emb.begin(),emb.end());
+			graph.neighborhood(nb,visited,cc_candidates.back().first);
+			set<pair<Injection*,int>> inj_candidates;
+			auto candidate = cc_candidates.begin();
+			for(auto& r_nodes : nb){
+				if(r_nodes.first == 0)
+					continue;
+				for(auto node : r_nodes.second){//fill inj_candidates with neighborhood injs
+					for(auto inj : node->getLifts())
+						inj_candidates.emplace(inj,r_nodes.first);
+				}
+				while(candidate != cc_candidates.end() && candidate->first <= r_nodes.first){
+					for(auto inj2_r : inj_candidates)
+						if(inj2_r.first->pattern().getId() == candidate->second){
+							//injection pair has a non local injection
+							//TODO at this point, cc-injs should be deleted from cc-inj containers...
+							two<int> key(cc_cc.first,candidate->second);
+							nlInjections[unary_mixes.at(key).front().second]->emplace(*this,inj,inj2_r.first,inj2_r.second);
+						}
+					candidate++;
+				}
+			}
+			while(candidate != cc_candidates.end()){
+				for(auto inj2_r : inj_candidates)//last time
+					if(inj2_r.first->pattern().getId() == candidate->second){
+						two<int> key(cc_cc.first,candidate->second);
+						nlInjections[unary_mixes.at(key).front().second]->emplace(*this,inj,inj2_r.first,inj2_r.second);
+					}
+				candidate++;
+			}
+		};
+		//testing on every inj of this cc
+		injections[cc->getId()]->fold(test);
+	}
 }
 
 void State::initActTree() {
 	if(activityTree)
 		delete activityTree;
-	activityTree = new data_structs::MyMaskedBinaryRandomTree<stack>(env.size<simulation::Rule>(),rng);
+	int rule_count = env.getRules().size();
+	//if(rule_count > 4)
+		activityTree = new data_structs::MyMaskedBinaryRandomTree<stack>(rule_count,rng);
+	//else
+	//	activityTree = new data_structs::SimpleTree(rule_count);
 	list<const simulation::Rule*> rules;
 	for(auto& rule : env.getRules())
 		rules.emplace_back(&rule);
@@ -574,16 +792,31 @@ void State::initActTree() {
 #endif*/
 }
 
+void State::plotOut() const {
+	plot.fill(*this,env);
+}
+
 
 void State::print() const {
 	graph.print(env);
 	cout << "Active Injections -> {\n";
 	int i = 0;
 	for(auto& cc : env.getComponents()){
+		int i = cc->getId();
 		if(injections[i]->count())
 			cout << "\t("<< i <<")\t" << injections[i]->count() <<
 			" injs of " << cc->toString(env) << endl;
-		i++;
+	}
+	for(auto& mix : env.getMixtures()){
+		int i = mix->getId();
+		matching::InjRandContainer<matching::MixInjection>* injs = nullptr;
+		try {
+			injs = nlInjections.at(i);
+		}
+		catch(std::out_of_range& e){ }
+		if(injs && injs->count())
+			cout << "\t("<< i <<")\t" << injs->count() <<
+			" mix-injs of " << mix->toString(env) << endl;
 	}
 	cout << "}\nActive Rules -> {\n";
 	for(auto& r : env.getRules()){

--- a/src/util/Exceptions.cpp
+++ b/src/util/Exceptions.cpp
@@ -21,9 +21,9 @@ const char* SemanticError::what() const _GLIBCXX_USE_NOEXCEPT {
 	static char c[250] ;//TODO??
 
 	if(loc.begin.filename == nullptr)
-		sprintf(c,"Semantic error in file (no-location):\n%s",msg);
+		sprintf(c,"Semantic error in file (no-location):\n\t%s",msg);
 	else
-		sprintf(c,"Semantic error in file \"%s\", line %d, characters %d-%d:\n%s",
+		sprintf(c,"Semantic error in file \"%s\", line %d, characters %d-%d:\n\t%s",
 	        loc.begin.filename->c_str(),loc.begin.line,loc.begin.column,loc.end.column,msg);
 	return c;
 }
@@ -57,7 +57,12 @@ void SyntaxError::setLocation(const yy::location &l){
 
 
 
-NullEvent::NullEvent(int e) : error(e) {}
+NullEvent::NullEvent(int e) : error(e) {
+#ifdef DEBUg
+	if(e < 0 || e > 6)
+		throw invalid_argument("invalid null event!");
+#endif
+}
 
 const char* NullEvent::what() const _GLIBCXX_USE_NOEXCEPT {
 	switch(error){
@@ -68,8 +73,8 @@ const char* NullEvent::what() const _GLIBCXX_USE_NOEXCEPT {
 	case 4:return "overapproximation clash";
 	case 5:return "invalid injection clash";
 	case 6:return "perturbation interrupting time";
-	default:return "invalid arg";
+	default:throw invalid_argument("invalid null event!");
 	}
-	return "invalid!!!!";
+	return nullptr;
 }
 

--- a/src/util/params.h
+++ b/src/util/params.h
@@ -33,5 +33,13 @@ class False : public std::exception {
 	virtual const char* what() const _GLIBCXX_USE_NOEXCEPT override {return "False exception";}
 };
 
+#ifdef DEBUG
+	#define IF_DEBUG_LVL(lvl,to_do) \
+		if(simulation::Parameters::get().verbose >= lvl) { to_do; }
+#else
+	#define IF_DEBUG_LVL(lvl,to_do) /* do not debug */
+#endif
+
 
 #endif
+


### PR DESCRIPTION
- Implementation of MixInjection, changes in several classes to deal
with unary Rules.
- Injections will be stored in liftsets of nodes and/or sites.
- Injections will be reused when they are removes in every liftSet.
- Bug-Fix: Last print when deadlock on event-print simulation.
- Simple-Tree class for testing purposes.